### PR TITLE
Fixed parsing cmd var %1

### DIFF
--- a/output.py
+++ b/output.py
@@ -123,7 +123,7 @@ def create_reg_add(data):
             result += filetype + "\\shell\\pyWin-" + command["regname"]
             result += "\\command]\r\n"
             result += "@=\"cmd /c " + configLoc.replace("\\", "\\\\")
-            result += "\\\\comStore\\\\" + str(command["id"]) + ".bat %1\"\r\n"
+            result += "\\\\comStore\\\\" + str(command["id"]) + ".bat \"%1\"\"\r\n"
             if "icon_path" in command and command["icon_path"] is not None:
                 create_icon(command["icon_path"], command["id"])
                 result += "\"Icon\"=\"" + configLoc.replace("\\", "\\\\")

--- a/output.py
+++ b/output.py
@@ -171,7 +171,7 @@ def create_reg_add(data):
         result += com["regname"] + "\\command]\r\n"
         result += "@=\"cmd /c " + configLoc.replace("\\", "\\\\")
         result += "\\\\comStore\\\\" + str(com["id"])
-        result += ".bat \\\"%1\\\"\"\r\n\r\n"
+        result += ".bat \\\"\"%1\"\\\"\"\r\n\r\n"
         create_bat(com)
     return result
 
@@ -191,7 +191,7 @@ def direct_add(data, parent):
             reg.create_command(
                 "pyWin-" + command["regname"], command["description"],
                 "cmd /c " + configLoc + "\\comStore\\" + str(command["id"])
-                + ".bat %1", filetype, iconPath)
+                + ".bat \"%1\"", filetype, iconPath)
             create_bat(command)
         for group in info["groups"]:
             groupObj = info["groups"][group]
@@ -317,7 +317,7 @@ def create_bat(command):
                 batString += "\r\n" + com
         if command["after"]:
             batString += "\r\ncmd /c " + configLoc + "\\comStore\\"
-            batString += str(command["after"]) + ".bat %1"
+            batString += str(command["after"]) + ".bat \"%1\""
         file.write(batString)
         file.close()
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,3 @@
+cx_Freeze==6.1
+Pillow==7.0.0
+PyQt5==5.14.1


### PR DESCRIPTION
Found a bug where the  `%1` arg does not get parsed correctly due to missing quotes around the variable.

An easy example is if the arg is a file or folder with spaces:
`D:\test\the is some random folder\my_file.mp4` would get parsed incorrectly as `D:\test\the`.
This is due to the registry entry lacking quotes around the `%1` 

I also added a requirements.txt file generated by the pipreqs tool for others to be able to test the code more quickly.